### PR TITLE
prevent UnicodeEncodeError

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -317,9 +317,9 @@ class CliInterface:
 
 if __name__ == "__main__":
     if sys.platform == 'win32':
-        print("Windows not supported 🦄")
+        print(str.encode("Windows not supported 🦄"))
         sys.exit(2)
     cliui = CliInterface()
     cliui.clear()
-    print (9 * " 👻 ")
+    print (9 * str.encode(" 👻 "))
     cliui.run()


### PR DESCRIPTION
Emojis caused the error 
`UnicodeEncodeError: 'ascii' codec can't encode character '\U0001f47b' in position 1: ordinal not in range(128)`

on an aarch64 Armbian Ubuntu system with default Python 3.6.8 installed.